### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -13,24 +13,24 @@ HD20x_dev	KEYWORD1
 #######################################
 HP20X_IIC_WriteCmd	KEYWORD2
 HP20X_IIC_ReadReg	KEYWORD2
-ReadTemperature	        KEYWORD2
-ReadPressure            KEYWORD2
-ReadAltitude            KEYWORD2
-Hex_to_Dec              KEYWORD2
+ReadTemperature		KEYWORD2
+ReadPressure	KEYWORD2
+ReadAltitude	KEYWORD2
+Hex_to_Dec	KEYWORD2
 HP20X_IIC_ReadData	KEYWORD2
 HP20X_IIC_ReadData3byte	KEYWORD2
 HP20X_IIC_WriteReg	KEYWORD2
-isAvailable           KEYWORD2
-begin               KEYWORD2 
-KalmanFilter        KEYWORD2
-Filter              KEYWORD2
-Gaussian_Noise_Cov  KEYWORD2
+isAvailable	KEYWORD2
+begin	KEYWORD2 
+KalmanFilter	KEYWORD2
+Filter	KEYWORD2
+Gaussian_Noise_Cov	KEYWORD2
 #######################################
 # Instances (KEYWORD2)
 #######################################
-HP20x KEYWORD2
-TwoWire KEYWORD2
-KalmanFilter KEYWORD2
+HP20x	KEYWORD2
+TwoWire	KEYWORD2
+KalmanFilter	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords